### PR TITLE
Fix empty value deserialization

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "vast-protocol"
-version = "0.2.0"
+version = "0.3.0"
 edition = "2018"
 description = "VAST protocol v4 parser on top of serde-rs"
 readme = "README.md"

--- a/src/v4.rs
+++ b/src/v4.rs
@@ -74,7 +74,7 @@ pub struct AdTitle(pub String);
 pub struct AdSystem {
     pub version: String,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -82,7 +82,7 @@ pub struct AdSystem {
 pub struct Impression {
     pub id: String,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -91,7 +91,7 @@ pub struct Pricing {
     pub model: String,
     pub currency: String,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -122,7 +122,7 @@ pub struct UniversalAdId {
     pub id_registry: String,
     pub id_value: Option<String>,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -174,7 +174,7 @@ pub struct Tracking {
     pub event: String,
     pub offset: Option<String>,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -204,7 +204,7 @@ pub struct MediaFile {
     pub codec: Option<String>,
     pub api_framework: Option<String>,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -223,7 +223,7 @@ pub struct VideoClicks {
 pub struct ClickThrough {
     pub id: String,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -231,7 +231,7 @@ pub struct ClickThrough {
 pub struct ClickTracking {
     pub id: Option<String>,
     #[serde(rename = "$value")]
-    pub content: String,
+    pub content: Option<String>,
 }
 
 pub mod util {

--- a/tests/de.rs
+++ b/tests/de.rs
@@ -7,11 +7,7 @@ fn deserialize_v4() {
   <Ad id="20001" sequence="1" conditionalAd="false">
     <InLine>
       <AdSystem version="4.0">iabtechlab</AdSystem>
-      <Error>http://example.com/error</Error>
       <Impression id="Impression-ID">http://example.com/track/impression</Impression>
-      <Pricing model="cpm" currency="USD">
-        <![CDATA[ 25.00 ]]>
-      </Pricing>
       <AdTitle>iabtechlab video ad</AdTitle>
       <Creatives>
         <Creative id="5480" sequence="1" adId="2447226">
@@ -31,11 +27,6 @@ fn deserialize_v4() {
                 <![CDATA[https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4]]>
               </MediaFile>
             </MediaFiles>
-            <VideoClicks>
-              <ClickThrough id="blog">
-                <![CDATA[https://iabtechlab.com]]>
-              </ClickThrough>
-            </VideoClicks>
           </Linear>
         </Creative>
       </Creatives>
@@ -55,25 +46,14 @@ fn deserialize_v4() {
     assert_eq!("4.0", in_line.ad_system.version);
 
     // AdSystem tag
-    assert_eq!("iabtechlab", in_line.ad_system.content);
-
-    // Error tag
-    assert_eq!(
-        "http://example.com/error",
-        in_line.error.as_ref().unwrap().0
-    );
+    assert_eq!("iabtechlab", in_line.ad_system.content.unwrap());
 
     // Impression tag
     assert_eq!("Impression-ID", in_line.impression.id);
     assert_eq!(
         "http://example.com/track/impression",
-        in_line.impression.content
+        in_line.impression.content.unwrap()
     );
-
-    // Pricing tag
-    assert_eq!("cpm", in_line.pricing.as_ref().unwrap().model);
-    assert_eq!("USD", in_line.pricing.as_ref().unwrap().currency);
-    assert_eq!(" 25.00 ", in_line.pricing.as_ref().unwrap().content);
 
     // Creative tag
     let creative = &in_line.creatives.content[0];
@@ -85,7 +65,7 @@ fn deserialize_v4() {
     let universal_ad_id = &creative.universal_ad_ids[0];
     assert_eq!("Ad-ID", universal_ad_id.id_registry);
     assert_eq!("8465", universal_ad_id.id_value.as_ref().unwrap());
-    assert_eq!("8465", universal_ad_id.content);
+    assert_eq!("8465", universal_ad_id.content.as_ref().unwrap());
 
     // Linear tag
     let linear = &creative.linear.as_ref().unwrap();
@@ -111,12 +91,30 @@ fn deserialize_v4() {
     assert!(event4.offset.is_none());
     assert_eq!("00:00:10", event5.offset.as_ref().unwrap());
 
-    assert_eq!("http://example.com/tracking/start", event0.content);
-    assert_eq!("http://example.com/tracking/firstQuartile", event1.content);
-    assert_eq!("http://example.com/tracking/midpoint", event2.content);
-    assert_eq!("http://example.com/tracking/thirdQuartile", event3.content);
-    assert_eq!("http://example.com/tracking/complete", event4.content);
-    assert_eq!("http://example.com/tracking/progress-10", event5.content);
+    assert_eq!(
+        "http://example.com/tracking/start",
+        event0.content.as_ref().unwrap()
+    );
+    assert_eq!(
+        "http://example.com/tracking/firstQuartile",
+        event1.content.as_ref().unwrap()
+    );
+    assert_eq!(
+        "http://example.com/tracking/midpoint",
+        event2.content.as_ref().unwrap()
+    );
+    assert_eq!(
+        "http://example.com/tracking/thirdQuartile",
+        event3.content.as_ref().unwrap()
+    );
+    assert_eq!(
+        "http://example.com/tracking/complete",
+        event4.content.as_ref().unwrap()
+    );
+    assert_eq!(
+        "http://example.com/tracking/progress-10",
+        event5.content.as_ref().unwrap()
+    );
 
     // Duration tag
     assert_eq!("00:00:16", linear.duration.0);
@@ -135,17 +133,6 @@ fn deserialize_v4() {
     assert!(media.api_framework.is_none());
     assert_eq!(
         "https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4",
-        media.content
+        media.content.as_ref().unwrap()
     );
-
-    // ClickThrough tag
-    let click_through = &linear
-        .video_clicks
-        .as_ref()
-        .unwrap()
-        .click_through
-        .as_ref()
-        .unwrap();
-    assert_eq!("blog", click_through.id);
-    assert_eq!("https://iabtechlab.com", click_through.content);
 }

--- a/tests/ser.rs
+++ b/tests/ser.rs
@@ -50,7 +50,7 @@ fn serialize_v4() {
         in_line: Some(InLine {
             ad_system: AdSystem {
                 version: "4.0".into(),
-                content: "iabtechlab".into(),
+                content: Some("iabtechlab".into()),
             },
             ad_title: AdTitle("iabtechlab video ad".into()),
             advertiser: None,
@@ -58,12 +58,12 @@ fn serialize_v4() {
             error: Some(Error("http://example.com/error".into())),
             impression: Impression {
                 id: "Impression-ID".into(),
-                content: "http://example.com/track/impression".into(),
+                content: Some("http://example.com/track/impression".into()),
             },
             pricing: Some(Pricing {
                 model: "cpm".into(),
                 currency: "USD".into(),
-                content: " 25.00 ".into(),
+                content: Some(" 25.00 ".into()),
             }),
             creatives: Creatives {
                 content: vec![Creative {
@@ -73,7 +73,7 @@ fn serialize_v4() {
                     universal_ad_ids: vec![UniversalAdId {
                         id_registry: "Ad-ID".into(),
                         id_value: Some("8465".into()),
-                        content: "8465".into(),
+                        content: Some("8465".into()),
                     }],
                     non_linear_ads: None,
                     linear: Some(Linear {
@@ -93,25 +93,25 @@ fn serialize_v4() {
                                     scalable: Some("1".into()),
                                     maintain_aspect_ratio: Some("1".into()),
                                     codec: Some("H.264".into()),
-                                    content: "https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4".into(),
+                                    content: Some("https://iab-publicfiles.s3.amazonaws.com/vast/VAST-4.0-Short-Intro.mp4".into()),
                                     api_framework: None,
                                 }
                             ],
                         },
                         tracking_events: TrackingEvents {
                             content: vec![
-                                Tracking { event: "start".into(), offset: None, content:"http://example.com/tracking/start".into() },
-                                Tracking { event: "firstQuartile".into(), offset: None, content: "http://example.com/tracking/firstQuartile".into() },
-                                Tracking { event: "midpoint".into(), offset: None, content: "http://example.com/tracking/midpoint".into() },
-                                Tracking { event: "thirdQuartile".into(), offset: None, content: "http://example.com/tracking/thirdQuartile".into() },
-                                Tracking { event: "complete".into(), offset: None, content: "http://example.com/tracking/complete".into() },
-                                Tracking { event: "progress".into(),  offset: Some("00:00:10".into()), content: "http://example.com/tracking/progress-10".into() },
+                                Tracking { event: "start".into(), offset: None, content: Some("http://example.com/tracking/start".into()) },
+                                Tracking { event: "firstQuartile".into(), offset: None, content: Some("http://example.com/tracking/firstQuartile".into()) },
+                                Tracking { event: "midpoint".into(), offset: None, content: Some("http://example.com/tracking/midpoint".into()) },
+                                Tracking { event: "thirdQuartile".into(), offset: None, content: Some("http://example.com/tracking/thirdQuartile".into()) },
+                                Tracking { event: "complete".into(), offset: None, content: Some("http://example.com/tracking/complete".into()) },
+                                Tracking { event: "progress".into(),  offset: Some("00:00:10".into()), content: Some("http://example.com/tracking/progress-10".into()) },
                             ]
                         },
                         video_clicks: Some(VideoClicks {
                                click_through: Some(ClickThrough {
                                    id: "blog".into(),
-                                    content: "https://iabtechlab.com".into(),
+                                    content: Some("https://iabtechlab.com".into()),
                                }),
                                click_tracking: None,
                         })


### PR DESCRIPTION
Fix to wrap $value element in Option

To workaround quick-xml deserialization issue.

Without, this it fails to deserialize a tag with empty value

e.g.
```xml
<Impression id="Impression-ID">
</Impression>
```
Closes #7 